### PR TITLE
Fix panic

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -62,15 +62,15 @@ func (s *Stack) Equal(stack *Stack) bool {
 		return true
 	case s.size != stack.size:
 		return false
-	}
-
-	for i := 0; i < s.size; i++ {
-		if s.values[i] != stack.values[i] {
-			return false
+	default:
+		for i := 0; i < s.size; i++ {
+			if s.values[i] != stack.values[i] {
+				return false
+			}
 		}
-	}
 
-	return true
+		return true
+	}
 }
 
 // Peek returns the top of the stack without modifying the stack's
@@ -98,6 +98,10 @@ func (s *Stack) Pop() interface{} {
 func (s *Stack) Push(values ...interface{}) *Stack {
 	n := len(s.values) - s.size // Number of values that can be copied to the stack's values
 	if 0 < n {
+		if len(values) < n {
+			n = len(values)
+		}
+
 		copy(s.values[s.size:], values[:n])
 		s.size += n
 	}

--- a/stack_test.go
+++ b/stack_test.go
@@ -119,3 +119,36 @@ func TestStack(t *testing.T) {
 		t.Errorf("\nexpected %v\nreceived %v\n", nil, rec)
 	}
 }
+
+func TestCopyEqual(t *testing.T) {
+	exp := New(0, 1, 2, 3, 4)
+	rec := exp.Copy()
+
+	// Test self equality
+	if !exp.Equal(exp) {
+		t.Errorf("\nexpected %v to equal itself\n", exp)
+	}
+
+	// Test same sizes, same values
+	if !exp.Equal(rec) {
+		t.Errorf("\nexpected %v to equal %v\n", exp, rec)
+	}
+
+	// Test different sizes
+	rec.Pop()
+	if exp.Equal(rec) {
+		t.Errorf("\nexpected %v to not equal %v\n", exp, rec)
+	}
+
+	// Test same size, different values
+	rec.Push(5)
+	if exp.Equal(rec) {
+		t.Errorf("\nexpected %v to not equal %v\n", exp, rec)
+	}
+
+	// Test shallow copy
+	rec = exp
+	if !exp.Equal(exp) {
+		t.Errorf("\nexpected %v to equal itself\n", exp)
+	}
+}


### PR DESCRIPTION
Stack.Push method panicked on index-out-of-bounds. This change prevents this panic.  Additional testing for Stack.Copy and Stack.Equal was added.